### PR TITLE
Feature/6 Create API docs

### DIFF
--- a/_web/build.gradle
+++ b/_web/build.gradle
@@ -3,4 +3,5 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
 }

--- a/_web/src/main/java/io/nche/comfiguration/OpenApiConfiguration.java
+++ b/_web/src/main/java/io/nche/comfiguration/OpenApiConfiguration.java
@@ -1,0 +1,37 @@
+package io.nche.comfiguration;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+public class OpenApiConfiguration {
+
+    private static String VERSION;
+
+    @Bean
+    public OpenAPI api(){
+        return new OpenAPI()
+                .info(apiInfo())
+                .externalDocs(springdocDoc());
+    }
+
+
+    public Info apiInfo() {
+        return new Info().title("Swagger API 문서")
+                .description("API와 연동된 Swagger 문서입니다.")
+                .version(VERSION);
+    }
+
+    public ExternalDocumentation springdocDoc(){
+        return new ExternalDocumentation()
+                .description("springdoc-openapi Docs")
+                .url("https://springdoc.org/");
+    }
+
+    @Value("${api.version}")
+    private void setVERSION(String version){
+        VERSION = version;
+    }
+}

--- a/_web/src/main/java/io/nche/configuration/OpenApiConfiguration.java
+++ b/_web/src/main/java/io/nche/configuration/OpenApiConfiguration.java
@@ -1,4 +1,4 @@
-package io.nche.comfiguration;
+package io.nche.configuration;
 
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/_web/src/main/resources/application.yml
+++ b/_web/src/main/resources/application.yml
@@ -1,1 +1,16 @@
+api:
+  version: v1
 
+springdoc:
+  version: ${api.version}
+  api-docs:
+    path: /api-docs/${api.version}
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    operations-sorter: alpha
+    tags-sorter: alpha
+    path: /${api.version}/swagger.html
+    disable-swagger-default-url: true
+  paths-to-match:
+    - /api/${api.version}/**


### PR DESCRIPTION
## Add dependency `springdoc-openapi-ui`

## Add springdoc settings and environment variable
> ### Springdoc settings honey tip 🍯
> The `supported-submit-methods` array contains `'get'`, `'post'`, `'patch'`, `'put'`, `'delete'`, `'options'`.
> But if you leave an empty array, you can't try-out API, only use swagger as a API document.
> Disable try-out feature is not officially supported, so you can use it as a trick.😋
> ```yaml
> springdoc:
>   swagger-ui:
>     supported-submit-methods: []
> ```
>
> ### Environment variable
> - They can be binding ☺ so I use the version property is environment ~ global🌏 ~ variable. 
> 
> 📁 /_web/src/main/resources/application.yml
> ```yaml
> api:
>  version: v1
>```
> 📁 /_web/src/main/java/io/nche/configuration/OpenApiConfiguration.java
> ```java
> private static String VERSION;
>
> @Value("${api.version}")
> private void setVERSION(String version){
>     VERSION = version;
> }
> ```

## Create OpenAPI configuration bean🫘
> I found it a bit disappointing.
> I tried to set up multiple external documents information. 
> Because method call chain is continuously possible.
> But it only supported only one url and description set last.
> Of course.
> It's like a builder chain doing setter things.
> I just kept overwriting the values. 😂
>
> 📁 /_web/src/main/java/io/nche/configuration/OpenApiConfiguration.java
> ```java
> public ExternalDocumentation springdocDoc(){
>   return new ExternalDocumentation()
>             .description("aaadocs")
>             .url("https://aaa.docs/");
> }
> ```
> 📁 /io/swagger/v3/oas/models/ExternalDocumentation.java
> ```java
> public class ExternalDocumentation {
>   private String description = null;
>   private String url = null;
>
>   public ExternalDocumentation url(String url) {
>       this.url = url;
>       return this;
>   }
>   public ExternalDocumentation description(String description) {
>       this.description = description;
>       return this;
>   }
> /* ellipsis */
> }
> ```

Solved: #6 